### PR TITLE
fix: not push `ConnectMetaEvent` after connection

### DIFF
--- a/onebot_event.go
+++ b/onebot_event.go
@@ -41,7 +41,16 @@ type marshaledEvent struct {
 }
 
 func (ob *OneBot) openEventListenChan() <-chan marshaledEvent {
-	ch := make(chan marshaledEvent) // TODO: channel size
+	ch := make(chan marshaledEvent, 1)
+	connectMetaEvent := MakeConnectMetaEvent(ob.Impl, Version, OneBotVersion)
+	ob.Logger.Debugf("事件: %#v", connectMetaEvent)
+	ob.Logger.Infof("事件 `%v` 开始推送", connectMetaEvent.Name())
+	eventBytes, _ := json.Marshal(connectMetaEvent)
+	ch <- marshaledEvent{
+		name:  connectMetaEvent.Name(),
+		bytes: eventBytes,
+		raw:   &connectMetaEvent,
+	}
 	ob.eventListenChansLock.Lock()
 	ob.eventListenChans = append(ob.eventListenChans, ch)
 	ob.eventListenChansLock.Unlock()

--- a/proto_event.go
+++ b/proto_event.go
@@ -92,6 +92,21 @@ func MakeMetaEvent(time time.Time, detailType string) MetaEvent {
 	}
 }
 
+type VersionStruct struct {
+	Impl          string `json:"impl"`
+	Version       string `json:"version"`
+	OnebotVersion string `json:"onebot_version"`
+}
+
+type ConnectMetaEvent struct {
+	MetaEvent
+	Version VersionStruct `json:"version"`
+}
+
+func MakeConnectMetaEvent(impl, v, onebotVersion string) ConnectMetaEvent {
+	return ConnectMetaEvent{MetaEvent: MakeMetaEvent(time.Now(), "connect"), Version: VersionStruct{impl, v, onebotVersion}}
+}
+
 // MessageEvent 表示一个消息事件.
 type MessageEvent struct {
 	Event


### PR DESCRIPTION
连接Bot后在推送消息事件时因为缺失`ConnectMetaEvent`而出错导致断开连接，在issues里面看到了这个问题，但是貌似已经修复的dev分支被删除了，所以再pr一下